### PR TITLE
Iss21 push single branch

### DIFF
--- a/.github/workflows/mirror_wait.yml
+++ b/.github/workflows/mirror_wait.yml
@@ -17,7 +17,6 @@ jobs:
         MODE: 'mirror'
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
         FORCE_PUSH: "true"
-        PRUNE: "true"
         GITLAB_HOSTNAME: "codebase.helmholtz.cloud"
         GITLAB_PROJECT_ID: "6627"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -27,7 +26,6 @@ jobs:
         MODE: 'get_status'
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
         FORCE_PUSH: "true"
-        PRUNE: "true"
         GITLAB_HOSTNAME: "codebase.helmholtz.cloud"
         GITLAB_PROJECT_ID: "6627"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -37,7 +35,6 @@ jobs:
         MODE: 'both'
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
         FORCE_PUSH: "true"
-        PRUNE: "true"
         GITLAB_HOSTNAME: "codebase.helmholtz.cloud"
         GITLAB_PROJECT_ID: "6627"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -130,10 +130,6 @@ in the jobs. By this, only those jobs can access the variables.
 - The following environment-variables can be kept as they are:
   - `FORCE_PUSH` is set to force-push to the Gitlab-Repo, to make sure,
   the Gitlab-Repo stays in sync with the main GitHub-repository.
-  - `PRUNE` is used to decide if git shall remove remote branches, that
-  have been removed locally. If only a single repo mirrors to the remote repo,
-  `PRUNE` can be kept as `true`. Otherwise, it may help to set to `false`
-  to avoid errors from deleting protected remote branches.
   - `GITHUB_TOKEN` is used to authorize internal actions.
   The secret is set automatically by GitHub.
   - `GITLAB_TOKEN` is used to authorize actions with the Gitlab-repo.

--- a/examples/.github/workflows/mirror_combined.yml
+++ b/examples/.github/workflows/mirror_combined.yml
@@ -17,7 +17,6 @@ jobs:
         MODE: 'both' # Either 'mirror', 'get_status', or 'both'
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
         FORCE_PUSH: "true"
-        PRUNE: "true"
         GITLAB_HOSTNAME: "codebase.helmholtz.cloud"
         GITLAB_PROJECT_ID: "6627"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/.github/workflows/mirror_splitted.yml
+++ b/examples/.github/workflows/mirror_splitted.yml
@@ -17,7 +17,6 @@ jobs:
         MODE: 'mirror' # Either 'mirror', 'get_status', or 'both'
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
         FORCE_PUSH: "true"
-        PRUNE: "true"
         GITLAB_HOSTNAME: "codebase.helmholtz.cloud"
         GITLAB_PROJECT_ID: "6627"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -33,7 +32,6 @@ jobs:
         MODE: 'get_status' # Either 'mirror', 'get_status', or 'both'
         GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
         FORCE_PUSH: "true"
-        PRUNE: "true"
         GITLAB_HOSTNAME: "codebase.helmholtz.cloud"
         GITLAB_PROJECT_ID: "6627"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/mirror.sh
+++ b/mirror.sh
@@ -16,10 +16,14 @@ echo "adding gitlab-repo as remote"
 git remote add gitlab "https://TOKENUSER:${GITLAB_TOKEN}@${GITLAB_REPO_URL}"
 # Get current state of local git
 git status
+sh -c "git checkout ${GITHUB_REF_NAME}"
+git status
 # Get the current state of the single branch from the GitHub-Repo
 sh -c "git fetch --prune --no-tags --force origin ${GITHUB_REF_NAME}"
 git status
 sh -c "git pull --no-tags --force origin ${GITHUB_REF_NAME}"
+
+git status
 
 # Push the current state of the repo to GitLab
 if [ "${FORCE_PUSH:-}" = "true" ]; then

--- a/mirror.sh
+++ b/mirror.sh
@@ -15,16 +15,11 @@ echo "URL is https://${GITLAB_REPO_URL}"
 echo "adding gitlab-repo as remote"
 git remote add gitlab "https://TOKENUSER:${GITLAB_TOKEN}@${GITLAB_REPO_URL}"
 # Get current state of local git
-git status
 sh -c "git checkout ${GITHUB_REF_NAME}"
-git status
 # Get the current state of the single branch from the GitHub-Repo
 sh -c "git fetch --prune --no-tags --force origin ${GITHUB_REF_NAME}"
-git status
 sh -c "git pull --no-tags --force origin ${GITHUB_REF_NAME}"
-
 git status
-
 # Push the current state of the repo to GitLab
 if [ "${FORCE_PUSH:-}" = "true" ]; then
   # Force push is used to make sure the gitlab-repo is the same as github

--- a/mirror.sh
+++ b/mirror.sh
@@ -6,9 +6,6 @@
 
 set -u
 
-# Define what branches and tags, etc to fetch and to push
-branch="+refs/heads/*:refs/heads/* +refs/tags/*:refs/tags/* +refs/pull/*:refs/heads/pull/*"
-
 # Get the URL of the repo
 echo "Getting the URL of the repo"
 GITLAB_REPO_URL=$(curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN" --silent "https://${GITLAB_HOSTNAME}/api/v4/projects/${GITLAB_PROJECT_ID}" | jq '.http_url_to_repo' | sed -e 's/http:\/\///' -e 's/https:\/\///' -e 's/"//g')
@@ -17,33 +14,26 @@ echo "URL is https://${GITLAB_REPO_URL}"
 # Add the remote Gitlab-Repo to the local git
 echo "adding gitlab-repo as remote"
 git remote add gitlab "https://TOKENUSER:${GITLAB_TOKEN}@${GITLAB_REPO_URL}"
-# Get the current state of the GitHub-Repo
-sh -c "git fetch --force origin $branch"
+# Get current state of local git
+git status
+# Get the current state of the single branch from the GitHub-Repo
+sh -c "git fetch --prune --no-tags --force origin ${GITHUB_REF_NAME}"
+git status
+sh -c "git pull --no-tags --force origin ${GITHUB_REF_NAME}"
 
 # Push the current state of the repo to GitLab
 if [ "${FORCE_PUSH:-}" = "true" ]; then
   # Force push is used to make sure the gitlab-repo is the same as github
   # If gitlab diverges, all changes from github are mirrored to GitLab
   # even if that overwrites changes
-  if [ "${PRUNE:-}" = "true" ]; then
-    # Check if the remote repo shall be pruned. Pruning leads to fewer obsolete
-    # and stale branches, but can lead to errors if multiple repos push there
-    sh -c "git push --prune --force gitlab $branch"
-  else
-    sh -c "git push --force gitlab $branch"
-  fi
+  sh -c "git push --force gitlab ${GITHUB_REF_NAME}"
 else
   # If pushing without "force" creates merge-conflicts, the push is aborted
-  if [ "${PRUNE:-}" = "true" ]; then
-    sh -c "git push --prune gitlab $branch"
-  else
-    sh -c "git push gitlab $branch"
-  fi
+  sh -c "git push gitlab ${GITHUB_REF_NAME}"
 fi
 # Get the return-code of pushing
 ret_code=$?
-if [ $ret_code = 0 ]
-then
+if [ $ret_code = 0 ]; then
   # Report, that pushing is done and add newline afterwards for formatting
   echo "Done pushing git-repo to https://${GITLAB_REPO_URL}"
 else


### PR DESCRIPTION
Closes #21 
Now only the current branch is mirrored to gitlab instead of mirroring everything from the git repo to gitlab.
This should reduce the number of started jobs (thus, saving computation-time).