### PR TITLE
Rename secret in example to fit README

### DIFF
--- a/examples/.github/workflows/mirror_pull_requests.yml
+++ b/examples/.github/workflows/mirror_pull_requests.yml
@@ -83,7 +83,7 @@ jobs:
         uses: jakob-fritz/github2lab_action@main
         env:
           MODE: 'all' # Either 'mirror', 'get_status', 'get_artifact', or 'all'
-          GITLAB_TOKEN: ${{ secrets.GITLAB_SECRET }}
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
           FORCE_PUSH: "true"
           GITLAB_HOSTNAME: "codebase.helmholtz.cloud"
           GITLAB_PROJECT_ID: "6627"


### PR DESCRIPTION
The secret for the GitLab token was named differently in the pull request example than in the README and the other examples (`GITLAB_TOKEN` vs `GITLAB_SECRET`). 

