### PR TITLE
Avoid exiting too fast to get error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ SPDX-License-Identifier: CC0-1.0
 
 - Removed `-e` flag when executing shell-scripts, as this leads to
 early exit without printing the error-message from the child process
+(Thank you to "sk1p" (Alexander Clausen) for pointing me to this; see #42)
+
+## 0.8.1
+
+- Added image of workflow to README
+- Added check of Gitlab-URL to early exit issues with empty URLs
 
 ## 0.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ SPDX-License-Identifier: CC0-1.0
 
 # Changelog
 
+## 0.9
+
+- Removed `-e` flag when executing shell-scripts, as this leads to
+early exit without printing the error-message from the child process
+
 ## 0.8
 
 - Added code to trigger a new pipeline when no code changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ SPDX-License-Identifier: CC0-1.0
 - Removed `-e` flag when executing shell-scripts, as this leads to
 early exit without printing the error-message from the child process
 (Thank you to "sk1p" (Alexander Clausen) for pointing me to this; see #42)
+- Added two more states in which the Gitlab-CI can be, which are fine and no final result (created, preparing). Therefore, the action does not exit on those states.
 
 ## 0.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ early exit without printing the error-message from the child process
 ## 0.8.1
 
 - Added image of workflow to README
-- Added check of Gitlab-URL to early exit issues with empty URLs
+- Added check of Gitlab-URL to exit early when having empty URLs
 
 ## 0.8
 

--- a/get_ci_state.sh
+++ b/get_ci_state.sh
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-set -u -e
+set -u
 
 # Set a default waiting-time in seconds between queries,
 # if the pipeline finished

--- a/get_ci_state.sh
+++ b/get_ci_state.sh
@@ -46,7 +46,7 @@ echo "Poll timeout set to ${POLL_TIMEOUT} s"
 ci_status="pending"
 
 # Repeat until the pipeline is neither pending nor running
-until [ "$ci_status" != "pending" ] && [ "$ci_status" != "running" ]
+until [ "$ci_status" != "created" ] && [ "$ci_status" != "preparing" ] && [ "$ci_status" != "pending" ] && [ "$ci_status" != "running" ]
 do
   # Wait some seconds
    sleep "$POLL_TIMEOUT"

--- a/mirror.sh
+++ b/mirror.sh
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-set -u -e
+set -u
 
 # Get the URL of the repo
 echo "Getting the URL of the repo"


### PR DESCRIPTION
The scripts exited too fast, so that the error messages of the called commands were not forwarded. This left users without hints on where a problem occurred from.