### PR TITLE
Error message when fetching pipeline id fails

### DIFF
--- a/get_ci_state.sh
+++ b/get_ci_state.sh
@@ -36,7 +36,7 @@ do
   pipeline_id_attempt=$((pipeline_id_attempt + 1))
   if [ "$pipeline_id_attempt" -gt "5" ]
   then
-    echo "Failed to fetch pipeline id"
+    echo "Failed to fetch pipeline id for ${used_sha}"
     exit 1
   fi
 done

--- a/get_ci_state.sh
+++ b/get_ci_state.sh
@@ -36,6 +36,7 @@ do
   pipeline_id_attempt=$((pipeline_id_attempt + 1))
   if [ "$pipeline_id_attempt" -gt "5" ]
   then
+    echo "Failed to fetch pipeline id"
     exit 1
   fi
 done


### PR DESCRIPTION
I was getting [another silent failure](https://github.com/LiberTEM/LiberTEM/actions/runs/17095073254/job/48477486719); the last output was "Triggered CI for branch refs/heads/master", so I think it must have been a failure to fetch the pipeline id.

It would be nice of course to capture the actual error message of the last `curl` run instead, but I didn't find an easy way to implement that in a bash script.